### PR TITLE
fix paths and update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,4 @@
-/*
-  set prefix = 'babel-plugin-' if you load individual plugins in package.json
-*/
-var prefix = './node_modules/babel-preset-es2015/node_modules/babel-plugin-'
-
-function _r(p) { return require(prefix + p) }
+function _r(p) { return require('babel-plugin-' + p) }
 
 module.exports = {
   plugins: [

--- a/index.js
+++ b/index.js
@@ -1,24 +1,31 @@
+/*
+  set prefix = 'babel-plugin-' if you load individual plugins in package.json
+*/
+var prefix = './node_modules/babel-preset-es2015/node_modules/babel-plugin-'
+
+function _r(p) { return require(prefix + p) }
+
 module.exports = {
   plugins: [
-   ['transform-es2015-template-literals', {'loose': true}],
-    'transform-es2015-literals',
-    'transform-es2015-function-name',
-    'transform-es2015-arrow-functions',
-    'transform-es2015-block-scoped-functions',
-    ['transform-es2015-classes', {'loose': true}],
-    'transform-es2015-object-super',
-    'transform-es2015-shorthand-properties',
-    ['transform-es2015-computed-properties', {'loose': true}],
-    ['transform-es2015-for-of', {'loose': true}],
-    'transform-es2015-sticky-regex',
-    'transform-es2015-unicode-regex',
-    'check-es2015-constants',
-    ['transform-es2015-spread', {'loose': true}],
-    'transform-es2015-parameters',
-    ['transform-es2015-destructuring', {'loose': true}],
-    'transform-es2015-block-scoping',
-    'transform-es2015-typeof-symbol',
-    ['transform-es2015-modules-commonjs', { 'allowTopLevelThis': true }],
-    ['transform-regenerator', { 'async': false, 'asyncGenerators': false }]
+   [_r('transform-es2015-template-literals'), {'loose': true}],
+    _r('transform-es2015-literals'),
+    _r('transform-es2015-function-name'),
+    _r('transform-es2015-arrow-functions'),
+    _r('transform-es2015-block-scoped-functions'),
+   [_r('transform-es2015-classes'), {'loose': true}],
+    _r('transform-es2015-object-super'),
+    _r('transform-es2015-shorthand-properties'),
+   [_r('transform-es2015-computed-properties'), {'loose': true}],
+   [_r('transform-es2015-for-of'), {'loose': true}],
+    _r('transform-es2015-sticky-regex'),
+    _r('transform-es2015-unicode-regex'),
+    _r('check-es2015-constants'),
+   [_r('transform-es2015-spread'), {'loose': true}],
+    _r('transform-es2015-parameters'),
+   [_r('transform-es2015-destructuring'), {'loose': true}],
+    _r('transform-es2015-block-scoping'),
+    _r('transform-es2015-typeof-symbol'),
+   [_r('transform-es2015-modules-commonjs'), { 'allowTopLevelThis': true }],
+   [_r('transform-regenerator'), { 'async': false, 'asyncGenerators': false }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-es2015-riot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The default riot babel preset ",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
     "moment": "^2.10.6",
-    "riot-compiler": "^2.3.16-beta",
+    "riot-compiler": "^2.3.19",
     "shelljs": "^0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-es2015-riot",
-  "version": "1.0.1",
+  "version": "6.3.13",
   "description": "The default riot babel preset ",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,26 @@
   },
   "homepage": "https://github.com/riot/babel-preset-es2015-riot#readme",
   "dependencies": {
-    "babel-preset-es2015": "^6.3.13"
+    "babel-plugin-transform-es2015-template-literals": "^6.3.13",
+    "babel-plugin-transform-es2015-literals": "^6.3.13",
+    "babel-plugin-transform-es2015-function-name": "^6.3.13",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+    "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+    "babel-plugin-transform-es2015-classes": "^6.3.13",
+    "babel-plugin-transform-es2015-object-super": "^6.3.13",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+    "babel-plugin-transform-es2015-for-of": "^6.3.13",
+    "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+    "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+    "babel-plugin-check-es2015-constants": "^6.3.13",
+    "babel-plugin-transform-es2015-spread": "^6.3.13",
+    "babel-plugin-transform-es2015-parameters": "^6.3.13",
+    "babel-plugin-transform-es2015-destructuring": "^6.3.13",
+    "babel-plugin-transform-es2015-block-scoping": "^6.3.13",
+    "babel-plugin-transform-es2015-typeof-symbol": "^6.3.13",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.3.13",
+    "babel-plugin-transform-regenerator": "^6.3.13"
   },
   "devDependencies": {
     "babel-core": "^6.3.17",

--- a/test/runner.js
+++ b/test/runner.js
@@ -5,6 +5,8 @@ var compiler = require('riot-compiler'),
   preset
 
 describe('Babel parser preset', function() {
+  this.timeout(8000) // for slow pcs
+
   it('can require all the plugins', function() {
     preset = require('../')
   })


### PR DESCRIPTION
v1.0.1
This should fix the path problem.

btw, I think is better set the version to 6.3.13 and list each plugin in package.json with "^6.3.13", as the oficial presets, so that users know that version of babel is included.